### PR TITLE
Refactor for easier adding of learn modules

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -7,20 +7,19 @@ const msalConfig = {
         redirectUri: 'http://localhost:8080'
     }
 };
-const msalRequest = { scopes: ['user.read'] };
-
+const msalRequest = { scopes: [] };
+function ensureScope (scope) {
+    if (!msalRequest.scopes.some((s) => s.toLowerCase() === scope.toLowerCase())) {
+        msalRequest.scopes.push(scope);
+    }
+}
 //Initialize MSAL client
 const msalClient = new msal.PublicClientApplication(msalConfig);
 
+// Log the user in
 async function signIn() {
     const authResult = await msalClient.loginPopup(msalRequest);
     sessionStorage.setItem('msalAccount', authResult.account.username);
-    // Get the user's profile from Graph
-    const user = await getUser();
-    // Save the profile in session storage
-    sessionStorage.setItem('graphUser', JSON.stringify(user));  
-    //display name of the user
-    displayProfile(user);  
 }
 //Get token from Graph
 async function getToken() {

--- a/graph.js
+++ b/graph.js
@@ -1,17 +1,17 @@
-
-    // Create an authentication provider
-    const authProvider = {
-        getAccessToken: async () => {
-            // Call getToken in auth.js
-            return await getToken();
-        }
-    };
-    // Initialize the Graph client
-    const graphClient = MicrosoftGraph.Client.initWithMiddleware({ authProvider });
-    //Get user info from Graph
-    async function getUser() {
-        return await graphClient
-            .api('/me')
-            .select('id,displayName')
-            .get();
+// Create an authentication provider
+const authProvider = {
+    getAccessToken: async () => {
+        // Call getToken in auth.js
+        return await getToken();
     }
+};
+// Initialize the Graph client
+const graphClient = MicrosoftGraph.Client.initWithMiddleware({ authProvider });
+//Get user info from Graph
+async function getUser() {
+    ensureScope('user.read');
+    return await graphClient
+        .api('/me')
+        .select('id,displayName')
+        .get();
+}

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <div id="content" style="display: none;">
       <h4>Welcome <span id="userName"></span></h4>     
     </div>
-    <a id="signin" onclick="signIn(); return false;" href="#">
+    <a id="signin" onclick="displayUI(); return false;" href="#">
       <img src="./images/ms-symbollockup_signin_light.png" alt="Sign in with Microsoft" />
     </a>
   </main>

--- a/ui.js
+++ b/ui.js
@@ -1,13 +1,12 @@
-function displayProfile(user) {    
-    if (!user) {
-        return;
-    }
+async function displayUI() {    
+    await signIn();
 
-    // set user data
+    // Display info from user profile
+    const user = await getUser();
     var userName = document.getElementById('userName');
     userName.innerText = user.displayName;  
 
-    // hide login button and show user info
+    // Hide login button and initial UI
     var signInButton = document.getElementById('signin');
     signInButton.style = "display: none";
     var content = document.getElementById('content');


### PR DESCRIPTION
As (mostly) discussed w/@rabwill, this allows adding features which display Graph data immediately after login without the need to push a button. Previously in order to call the Graph during the initial page load required modifying displayProfile() in ui.js, which meant, for example, adding a call to displayFiles() to displayProfile() in my module where I want to display a list of OneDrive files on load.

 - Auth no longer calls ui.js and graph.js functions; it is more self-contained
 - displayProfile() is now displayUI() and there's a logical spot to add more display logic
 - No longer saves user profile from the Graph in session storage -- was this being used by a downstream project?
 - Rather than hammer msal.request from graph.js I added a small function ensureScope() to auth.js. IMO this is cleaner and I added a bit of logic to avoid duplicate scopes being added.
 - Code is shorter than before! (slightly)